### PR TITLE
Simplify tests a bit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from ubiquerg import powerset
 
 
 __author__ = "Vince Reuter"
-__email__ = "vreuter@virginia.edu"
+
 
 HEADLINE = "This is a short description."
 DETAIL_LINES = ["This description provides more detail",
@@ -47,18 +47,9 @@ CODE_EX1 = """{ex_tag}
     c = 3
 """.format(ex_tag=RST_EXAMPLE_TAG).splitlines(False)
 
-CODE_EX2 = """{ex_tag}
-
-.. code-block:: python
-
-    text = "this is the second example"
-    text += " and should parse separately from the first"
-""".format(ex_tag=RST_EXAMPLE_TAG).splitlines(False)
-
 TEMP_CLS_1 = "DummyClass"
 TEMP_CLS_2 = "Random"
-TEMP_CLS_3 = "Arbitrary"
-CLASS_NAMES = [TEMP_CLS_1, TEMP_CLS_2, TEMP_CLS_3]
+CLASS_NAMES = [TEMP_CLS_1, TEMP_CLS_2]
 
 MODLINES = """
 __author__ = "Vince Reuter"
@@ -75,12 +66,7 @@ class {c1}(object):
 
 class {c2}(object):
     pass
-
-
-class {c3}(object):
-    pass
-""".format(exports=make_exports_declaration(CLASS_NAMES),
-           c1=TEMP_CLS_1, c2=TEMP_CLS_2, c3=TEMP_CLS_3).splitlines(False)
+""".format(exports=make_exports_declaration(CLASS_NAMES), c1=TEMP_CLS_1, c2=TEMP_CLS_2).splitlines(False)
 
 
 SHORT_DESC_KEY = "headline"
@@ -99,7 +85,7 @@ PARAM_POOL = [{PAR_KEY: items} for items in
               powerset([BOOL_PARAM, FUNC_PARAM, ITER_PARAM, UNION_PARAM])]
 RETURN_POOL = [{RET_KEY: items} for items in [RETURN, RETURN_MUTLI_LINE]]
 ERROR_POOL = [{ERR_KEY: items} for items in powerset([VALUE_ERROR, TYPE_ERROR])]
-CODE_POOL = [{EXS_KEY: items} for items in powerset([CODE_EX1, CODE_EX2])]
+CODE_POOL = [{EXS_KEY: items} for items in powerset([CODE_EX1])]
 SPACE_POOL = [dict(zip(
     ("pre_tags_space", "trailing_space"), flags))
     for flags in itertools.product([False, True], [False, True])

--- a/tests/test_declared_exports.py
+++ b/tests/test_declared_exports.py
@@ -4,35 +4,13 @@ import itertools
 import os
 import pytest
 from lucidoc.docparse import PARSERS
-from tests.conftest import CLASS_NAMES, TEMP_CLS_1, TEMP_CLS_2, \
-    TEMP_CLS_3
+from tests.conftest import CLASS_NAMES, MODLINES
 from tests.helpers import exec_test, make_exports_declaration
 
 __author__ = "Vince Reuter"
-__email__ = "vreuter@virginia.edu"
 
 
 EXPORTS_KEY = "exports"
-
-MODLINES = """
-__author__ = "Vince Reuter"
-
-class {c1}(object):
-
-    def fun1(self):
-        pass
-
-    def fun2(self):
-        pass
-
-
-class {c2}(object):
-    pass
-
-
-class {c3}(object):
-    pass
-""".format(c1=TEMP_CLS_1, c2=TEMP_CLS_2, c3=TEMP_CLS_3).splitlines(False)
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/test_non_tags_sections.py
+++ b/tests/test_non_tags_sections.py
@@ -3,20 +3,17 @@
 import pytest
 import lucidoc
 from lucidoc.docparse import RST_EXAMPLE_TAG
-from tests.conftest import build_args_space, CODE_EX1, CODE_EX2, DESC_KEY, \
+from tests.conftest import build_args_space, CODE_EX1, DESC_KEY, \
     EXS_KEY, HEADLINE, DETAIL_LINES, LONG_DESC_KEY, SHORT_DESC_KEY
 from ubiquerg import powerset
 
 __author__ = "Vince Reuter"
-__email__ = "vreuter@virginia.edu"
 
 
 @pytest.mark.parametrize("blank_line_sep", [False, True])
 @pytest.mark.parametrize("pool", build_args_space(
     allow_empty=False,
-    **{EXS_KEY: [{EXS_KEY: items} for items in
-                 powerset([CODE_EX1, CODE_EX2], nonempty=True)]}
-))
+    **{EXS_KEY: [{EXS_KEY: items} for items in powerset([CODE_EX1], nonempty=True)]}))
 def test_examples(pool, ds_spec, blank_line_sep):
     """ Check that number of example blocks parsed is as expected. """
     parser = lucidoc.RstDocstringParser()


### PR DESCRIPTION
I expected a lot of the cases to be randomized and to trim by setting a lower threshold for passing (i.e., fewer cases), but actually the ~~cases here are built deterministically~~, and it looks like most of the input data actually differs. I trimmed a bit of what seemed redundant, though, and the suite runs in ~30s for me locally. And I guess to clarify the determinism, it's w.r.t. case structure and counts it seems, while some individual string values may be randomized where the actual value shouldn't matter.

Close #46 

```
============= 24976 passed, 3072 skipped, 2919 warnings in 23.70s ==============

```